### PR TITLE
chore: bump Vib action to v0.6.2

### DIFF
--- a/.github/workflows/vib-build.yml
+++ b/.github/workflows/vib-build.yml
@@ -18,10 +18,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: vanilla-os/vib-gh-action@v0.3.3-1
+    - uses: vanilla-os/vib-gh-action@v0.6.2
       with:
         recipe: 'recipe.yml'
-        plugins: 'Vanilla-OS/vib-fsguard:v1.2-1'
+        plugins: 'Vanilla-OS/vib-fsguard:v1.3-2'
 
     - name: Build the Docker image
       run: docker image build -f Containerfile --tag ghcr.io/vanilla-os/nvidia:main .

--- a/.github/workflows/vib-pr.yml
+++ b/.github/workflows/vib-pr.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - uses: vanilla-os/vib-gh-action@v0.3.3-1
+    - uses: vanilla-os/vib-gh-action@v0.6.2
       with:
         recipe: 'recipe.yml'
-        plugins: 'Vanilla-OS/vib-fsguard:v1.2-1'
+        plugins: 'Vanilla-OS/vib-fsguard:v1.3-2'
 
     - name: Build the Docker image
       run: docker image build -f Containerfile --tag vanillaos/nvidia:validation .

--- a/recipe.yml
+++ b/recipe.yml
@@ -1,97 +1,100 @@
-base: ghcr.io/vanilla-os/desktop:main
 name: Vanilla Desktop Nvidia
 id: vanilla-nvidia
-labels:
-  maintainer: Vanilla OS Contributors
-args:
-  DEBIAN_FRONTEND: noninteractive
-runs:
-- echo 'APT::Install-Recommends "1";' > /etc/apt/apt.conf.d/01norecommends
+stages:
+- id: build
+  base: ghcr.io/vanilla-os/desktop:main
+  singlelayer: false
+  labels:
+    maintainer: Vanilla OS Contributors
+  args:
+    DEBIAN_FRONTEND: noninteractive
+  runs:
+  - echo 'APT::Install-Recommends "1";' > /etc/apt/apt.conf.d/01norecommends
 
-modules:
-- name: init-setup
-  type: shell
-  commands:
-  - lpkg --unlock
-  - apt update
-
-- name: nvidia-driver
-  type: apt
-  source:
-    packages:
-    - nvidia-driver
-    - nvidia-vaapi-driver
-
-- name: nvidia-utilities
-  type: apt
-  source:
-    packages:
-    - nvidia-settings
-    - nvidia-smi
-    - switcheroo-control
-
-- name: vanilla-tools
-  type: shell
-  source:
-    type: tar
-    # switch to production build once in production
-    url: https://github.com/Vanilla-OS/vanilla-tools/releases/download/continuous/vanilla-tools.tar.gz
-  commands:
-  - mkdir -p /usr/bin
-  - cp /sources/vanilla-tools/nrun /usr/bin/nrun
-  - cp /sources/vanilla-tools/prime-switch /usr/bin/prime-switch
-  - chmod +x /usr/bin/nrun
-  - chmod +x /usr/bin/prime-switch
-
-- name: vanilla-prime-utility
-  type: meson
-  source:
-    type: git
-    url: https://github.com/Vanilla-OS/vanilla-prime-utility
-    branch: main
-    commit: latest
   modules:
-  - name: vanilla-prime-utility-deps-install
+  - name: init-setup
+    type: shell
+    commands:
+    - lpkg --unlock
+    - apt update
+
+  - name: nvidia-driver
     type: apt
     source:
       packages:
-      - build-essential
-      - gettext
-      - libadwaita-1-dev
-      - meson
+      - nvidia-driver
+      - nvidia-vaapi-driver
 
-- name: enable-wayland
-  type: shell
-  commands:
-  - mkdir -p /etc/udev/rules.d
-  - ln -s /dev/null /etc/udev/rules.d/61-gdm.rules
+  - name: nvidia-utilities
+    type: apt
+    source:
+      packages:
+      - nvidia-settings
+      - nvidia-smi
+      - switcheroo-control
 
-- name: cleanup
-  type: shell
-  commands:
-  - apt autoremove -y
-  - apt clean
-  - apt remove -y zutty gnome-shell-extension-prefs
-  - SUDO_FORCE_REMOVE=yes apt purge -y sudo
-  - lpkg --lock
+  - name: vanilla-tools
+    type: shell
+    source:
+      type: tar
+      # switch to production build once in production
+      url: https://github.com/Vanilla-OS/vanilla-tools/releases/download/continuous/vanilla-tools.tar.gz
+    commands:
+    - mkdir -p /usr/bin
+    - cp /sources/vanilla-tools/nrun /usr/bin/nrun
+    - cp /sources/vanilla-tools/prime-switch /usr/bin/prime-switch
+    - chmod +x /usr/bin/nrun
+    - chmod +x /usr/bin/prime-switch
 
-- name: fsguard
-  type: fsguard
-  CustomFsGuard: false
-  FsGuardLocation: "/usr/sbin/FsGuard"
-  GenerateKey: true
-  FilelistPaths: ["/usr/bin"]
-  modules:
-    - name: remove-prev-fsguard
-      type: shell
-      commands:
-        - rm -rf /FsGuard 
-        - rm -f ./minisign.pub ./minisign.key 
-        - chmod +x /usr/sbin/init
+  - name: vanilla-prime-utility
+    type: meson
+    source:
+      type: git
+      url: https://github.com/Vanilla-OS/vanilla-prime-utility
+      branch: main
+      commit: latest
+    modules:
+    - name: vanilla-prime-utility-deps-install
+      type: apt
+      source:
+        packages:
+        - build-essential
+        - gettext
+        - libadwaita-1-dev
+        - meson
 
-- name: cleanup2
-  type: shell
-  commands:
-    - rm -rf /tmp/*
-    - rm -rf /var/tmp/*
-    - rm -rf /sources
+  - name: enable-wayland
+    type: shell
+    commands:
+    - mkdir -p /etc/udev/rules.d
+    - ln -s /dev/null /etc/udev/rules.d/61-gdm.rules
+
+  - name: cleanup
+    type: shell
+    commands:
+    - apt autoremove -y
+    - apt clean
+    - apt remove -y zutty gnome-shell-extension-prefs
+    - SUDO_FORCE_REMOVE=yes apt purge -y sudo
+    - lpkg --lock
+
+  - name: fsguard
+    type: fsguard
+    CustomFsGuard: false
+    FsGuardLocation: "/usr/sbin/FsGuard"
+    GenerateKey: true
+    FilelistPaths: ["/usr/bin"]
+    modules:
+      - name: remove-prev-fsguard
+        type: shell
+        commands:
+          - rm -rf /FsGuard 
+          - rm -f ./minisign.pub ./minisign.key 
+          - chmod +x /usr/sbin/init
+
+  - name: cleanup2
+    type: shell
+    commands:
+      - rm -rf /tmp/*
+      - rm -rf /var/tmp/*
+      - rm -rf /sources


### PR DESCRIPTION
## Changes

- Bump Vib action to `v0.6.2`.
- Update `recipe.yml` to the new syntax.