### PR TITLE
Revert "feat [closes #23]: add nvidia-cuda-toolkit package"

### DIFF
--- a/recipe.yml
+++ b/recipe.yml
@@ -25,12 +25,6 @@ stages:
       - nvidia-driver
       - nvidia-vaapi-driver
 
-  - name: nvidia-cuda
-    type: apt
-    source:
-      packages:
-      - nvidia-cuda-toolkit
-
   - name: nvidia-utilities
     type: apt
     source:


### PR DESCRIPTION
This reverts commit 12c3ead77575a01337f533912d86942398a07c6d. 
The changes took up too much space in the image.