### PR TITLE
fix: bump vib-fsguard to v1.5.2

### DIFF
--- a/.github/workflows/vib-build.yml
+++ b/.github/workflows/vib-build.yml
@@ -38,7 +38,7 @@ jobs:
     - uses: vanilla-os/vib-gh-action@v0.7.2
       with:
         recipe: 'recipe.yml'
-        plugins: 'Vanilla-OS/vib-fsguard:v1.5.1'
+        plugins: 'Vanilla-OS/vib-fsguard:v1.5.2'
 
     - uses: actions/upload-artifact@v4
       with:


### PR DESCRIPTION
This PR should be merged, after the desktop image workflow completes.