### PR TITLE
chore: use nvidia-kernel-open module

### DIFF
--- a/includes.container/etc/abroot/kargs
+++ b/includes.container/etc/abroot/kargs
@@ -1,0 +1,1 @@
+quiet splash bgrt_disable $vt_handoff lsm=integrity nvidia.NVreg_DynamicPowerManagement=0x02 nvidia.NVreg_PreserveVideoMemoryAllocations=1 nvidia.NVreg_TemporaryFilePath=/var/tmp nvidia-drm.fbdev=1

--- a/recipe.yml
+++ b/recipe.yml
@@ -56,12 +56,6 @@ stages:
     - chmod +x /usr/bin/nrun
     - chmod +x /usr/bin/prime-switch
 
-  - name: enable-wayland
-    type: shell
-    commands:
-    - mkdir -p /etc/udev/rules.d
-    - ln -s /dev/null /etc/udev/rules.d/61-gdm.rules
-
   - name: cleanup
     type: shell
     commands:

--- a/recipe.yml
+++ b/recipe.yml
@@ -25,8 +25,8 @@ stages:
     - curl -fSsL https://developer.download.nvidia.com/compute/cuda/repos/debian12/x86_64/3bf863cc.pub | gpg --dearmor -o /usr/share/keyrings/nvidia-drivers.gpg
     - echo 'deb [signed-by=/usr/share/keyrings/nvidia-drivers.gpg] https://developer.download.nvidia.com/compute/cuda/repos/debian12/x86_64/ /' > /etc/apt/sources.list.d/nvidia-drivers.list
     - apt-get update
-    - apt-get install nvidia-driver nvidia-vaapi-driver nvidia-settings nvidia-smi -y
-    - apt-mark hold nvidia-driver nvidia-vaapi-driver nvidia-settings nvidia-smi
+    - apt-get install nvidia-kernel-open nvidia-driver nvidia-vaapi-driver nvidia-settings nvidia-smi -y
+    - apt-mark hold nvidia-kernel-open nvidia-driver nvidia-vaapi-driver nvidia-settings nvidia-smi
 
   - name: extra-utilities
     type: apt


### PR DESCRIPTION
Should fix some issues with multiple-monitors (based on feedback from another user) and probably others.

## Merging rules

- Merging this PR makes Vanilla OS start supporting the [`nvidia-propietary`](https://github.com/Vanilla-OS/nvidia-propietary-image)
- We have to take note that older GPUs will not work, they should be pointed to use the new `nvidia-propietary`
- The installer must be updated to identify old GPUs (like 470.x or 390.x) and suggest the new `nvidia-propietary`
- We have to find a way to automatically update existing installations (I was thinking of just making a new `nvidia-open-image` image instead of `nvidia -propietary` so as existing installations do not get affected, but that would change nothing since existing installations with issues will just keep having issues and needs to switch to the new `nvidia-open` manually which is the same as doing the opposite)
- I suggest to wait for some more users testing the changes (by using the `mirkobrombin/nvidia-open` image, if this actually fixes some issues then it must be merged
- **DO NOT** merge this without first following the previous steps

## Where I tested

I do not have an external monitor to test. Anyway I tested this on 2 different laptops:
- GTX 1660
- RTX 4050

## What I tested

everything works fine, especially:
- switching PRIME profiles
- Wayland
- Xorg
- games (Steam via Flatpak/Apx (Ubuntu)/Cpak verified via MangoHUD

## Issues

had no issues of any type, also interesting point: boot was speeded up by about 3s, I don't know if it's related but I noticed it 4 out of 4 times

## Custom Kargs

none, just the default ones (quiet splash bgrt_disable $vt_handoff lsm=integrity)

## nvidia-smi

```
+-----------------------------------------------------------------------------------------+
| NVIDIA-SMI 555.42.06              Driver Version: 555.42.06      CUDA Version: N/A      |
|-----------------------------------------+------------------------+----------------------+
| GPU  Name                 Persistence-M | Bus-Id          Disp.A | Volatile Uncorr. ECC |
| Fan  Temp   Perf          Pwr:Usage/Cap |           Memory-Usage | GPU-Util  Compute M. |
|                                         |                        |               MIG M. |
|=========================================+========================+======================|
|   0  NVIDIA GeForce RTX 4050 ...    Off |   00000000:01:00.0 Off |                  N/A |
| N/A   45C    P3              8W /   35W |       8MiB /   6141MiB |      0%      Default |
|                                         |                        |                  N/A |
+-----------------------------------------+------------------------+----------------------+
                                                                                         
+-----------------------------------------------------------------------------------------+
| Processes:                                                                              |
|  GPU   GI   CI        PID   Type   Process name                              GPU Memory |
|        ID   ID                                                               Usage      |
|=========================================================================================|
|    0   N/A  N/A      3501      G   /usr/bin/gnome-shell                            1MiB |
+-----------------------------------------------------------------------------------------+
```

## cur-gpu

```
OpenGL version: 4.6 (Compatibility Profile) Mesa 24.1.3-2
OpenGL vendor: Intel
OpenGL renderer: Mesa Intel(R) Graphics (ADL GT2)
```

using `nrun`:

```
OpenGL version: 4.6.0 NVIDIA 555.42.06
OpenGL vendor: NVIDIA Corporation
OpenGL renderer: NVIDIA GeForce RTX 4050 Laptop GPU/PCIe/SSE2
```

## Does not fix/Does not change

I am including in this section some of the issues we are already tracking that does not get fixed and/or don't change with this change.

- some setups (currently 3 reports) remain stuck on the vanilla logo