### PR TITLE
fix: wayland session not showing and GDM freezes

### DIFF
--- a/.github/workflows/vib-build.yml
+++ b/.github/workflows/vib-build.yml
@@ -3,7 +3,7 @@ name: Vib Build
 on:
   push:
     branches:
-      - '535'
+      - 'main'
     tags:
       - '*'
   workflow_dispatch:

--- a/.github/workflows/vib-build.yml
+++ b/.github/workflows/vib-build.yml
@@ -3,7 +3,7 @@ name: Vib Build
 on:
   push:
     branches:
-      - 'main'
+      - '535'
     tags:
       - '*'
   workflow_dispatch:

--- a/includes.container/etc/abroot/kargs
+++ b/includes.container/etc/abroot/kargs
@@ -1,1 +1,1 @@
-quiet splash bgrt_disable $vt_handoff lsm=integrity nvidia.NVreg_DynamicPowerManagement=0x02 nvidia.NVreg_PreserveVideoMemoryAllocations=1 nvidia.NVreg_TemporaryFilePath=/var/tmp nvidia-drm.fbdev=1
+quiet splash bgrt_disable $vt_handoff lsm=integrity nvidia-drm.modeset=1

--- a/recipe.yml
+++ b/recipe.yml
@@ -19,34 +19,15 @@ stages:
     - lpkg --unlock
     - apt-get update
 
-  - name: nvidia-official-repo
-    type: shell
-    commands:
-    - curl -fSsL https://developer.download.nvidia.com/compute/cuda/repos/debian12/x86_64/3bf863cc.pub | gpg --dearmor -o /usr/share/keyrings/nvidia-drivers.gpg
-    - echo 'deb [signed-by=/usr/share/keyrings/nvidia-drivers.gpg] https://developer.download.nvidia.com/compute/cuda/repos/debian12/x86_64/ /' > /etc/apt/sources.list.d/nvidia-drivers.list
-    - apt-get update
-
-  - name: nvidia-official-driver
-    type: shell
-    commands:
-    - apt-mark hold nvidia-kernel-open nvidia-driver nvidia-vaapi-driver nvidia-settings nvidia-persistenced nvidia-smi libnvidia-cfg1 libnvidia-glcore libnvidia-glvkspirv libnvidia-gpucomp libnvidia-fbc1 nvidia-container-toolkit
-    modules:
-      - name: install-nvidia
-        type: apt
-        source:
-          packages:
-          - nvidia-kernel-open
-          - nvidia-driver
-          - nvidia-vaapi-driver
-          - nvidia-settings
-          - nvidia-persistenced
-          - nvidia-smi
-          - libnvidia-cfg1
-          - libnvidia-glcore
-          - libnvidia-glvkspirv
-          - libnvidia-gpucomp
-          - libnvidia-fbc1
-          - nvidia-container-toolkit
+  - name: install-nvidia
+    type: apt
+    source:
+      packages:
+      - nvidia-driver
+      - nvidia-vaapi-driver
+      - nvidia-settings
+      - nvidia-smi
+      - firmware-misc-nonfree
 
   - name: nvidia-sysd-units
     type: shell

--- a/recipe.yml
+++ b/recipe.yml
@@ -34,9 +34,9 @@ stages:
     commands:
     - mkdir -p /etc/systemd/system/systemd-suspend.service.wants
     - mkdir -p /etc/systemd/system/systemd-hibernate.service.wants
-    - ln -s /usr/lib/systemd/system/nvidia-suspend.service /etc/systemd/system/systemd-suspend.service.wants/nvidia-suspend.service
-    - ln -s /usr/lib/systemd/system/nvidia-hibernate.service /etc/systemd/system/systemd-hibernate.service.wants/nvidia-hibernate.service
-    - ln -s /usr/lib/systemd/system/nvidia-resume.service /etc/systemd/system/systemd-hibernate.service.wants/nvidia-resume.service
+    - ln -s /usr/lib/systemd/system/nvidia-suspend.service /etc/systemd/system/systemd-suspend.service.wants/nvidia-suspend.service || true
+    - ln -s /usr/lib/systemd/system/nvidia-hibernate.service /etc/systemd/system/systemd-hibernate.service.wants/nvidia-hibernate.service || true
+    - ln -s /usr/lib/systemd/system/nvidia-resume.service /etc/systemd/system/systemd-hibernate.service.wants/nvidia-resume.service || true
 
   - name: extra-utilities
     type: apt


### PR DESCRIPTION
This PR rollbacks drivers to 535 for many reasons:

- 535 comes from debian and are packaged with proper configurations
- users having issues with wayland (session not showing, gdm freezing) managed to fix with this rollback
- the repo we were using provides only beta drivers (I'll make a new [image](https://github.com/Vanilla-OS/nvidia-exp-image) with drivers installed from that repo for specific needs)
- we understand that dealing with problems of this type can drastically slow down the development of the project which is not worth the benefit of having more updated drivers
- 535 still supports recent hardware

closes https://github.com/Vanilla-OS/nvidia-image/issues/42
closes https://github.com/Vanilla-OS/nvidia-image/issues/41
closes https://github.com/Vanilla-OS/nvidia-image/issues/38

might fix https://github.com/Vanilla-OS/nvidia-image/issues/17